### PR TITLE
Strip hyphens and periods from component name input

### DIFF
--- a/bin/scripts/generateClassComponent.sh
+++ b/bin/scripts/generateClassComponent.sh
@@ -8,7 +8,7 @@ if [ $# -lt 2 ]; then
 fi
 
 if [ "$1" == "classComponent" ]; then
-supplied_name=$2
+supplied_name=${2//[-.]/} # remove hyphens and periods
 
 # Capitalized version of the component name
 Name="$(tr '[:lower:]' '[:upper:]' <<< ${supplied_name:0:1})${supplied_name:1}"

--- a/bin/scripts/generateStatelessComponent.sh
+++ b/bin/scripts/generateStatelessComponent.sh
@@ -8,7 +8,7 @@ if [ $# -lt 2 ]; then
 fi
 
 if [ "$1" == "statelessComponent" ]; then
-supplied_name=$2
+supplied_name=${2//[-.]/} # remove hyphens and periods
 
 # Capitalized version of the Component name
 Name="$(tr '[:lower:]' '[:upper:]' <<< ${supplied_name:0:1})${supplied_name:1}"


### PR DESCRIPTION
Hi! 👋 

## What Changed & Why

Previously, if you ran `generate` with a component name containing a hyphen or a period, it would not strip these from the input, resulting in illegal characters in JS names.

For example,

```
$ trt generate sc test-component
```

would yield a component in `index.js` that looked like this:

```
const Test-component = () => (...)
```

which would break.

Now, if you run the same command you should expect to see:

```
const TestComponent = () => (...)
```

## Testing

The above explains your expected output, but in short, any of the following commands should yield the same output:

```
$ trt generate sc TestComponent
> TestComponent created 

$ trt generate Test.component
> TestComponent created

$ trt generate test-component
> TestComponent created
```

and the component in `index.js` should match that shown in the section above.

## In Progress/Follow Up

I imagine there are a lot of characters we _could_ strip out of here in addition to these, but it might not be that useful (and I'm not even certain that periods are that necessary to include?). I saw this break on hyphens in a demo and have made that mistake myself, so that one at least seemed like the best place to start. Happy to modify as necessary if there have been sticking points for anyone else using this. 